### PR TITLE
Update internal/beacon: add an option to disable the integration with beacon server explicitly

### DIFF
--- a/internal/beacon/addr.go
+++ b/internal/beacon/addr.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -22,12 +23,19 @@ func LockFilePath() string {
 	return LockFile
 }
 
+var ErrIntegrationDisabled = errors.New("the integration with beacon server is disabled")
+
 // Address returns address of beacon server.
 // It returns value of CFT_BEACON_ADDR if exists.
-// If not exists, read from lockFile.
+// If the value of CFT_BEACON_ADDR equals "disabled", this returns ErrIntegrationDisabled.
+//
+// If the variable not exists, Address try to read from lockFile.
 func Address(ctx context.Context, lockFile string) (string, error) {
 	addr := os.Getenv(AddressEnv)
 	if addr != "" {
+		if strings.EqualFold(addr, "disabled") {
+			return "", ErrIntegrationDisabled
+		}
 		return addr, nil
 	}
 

--- a/internal/cmd/commands.go
+++ b/internal/cmd/commands.go
@@ -149,8 +149,12 @@ func (s *StopCommand) SetFlags(f *flag.FlagSet) {
 func (s *StopCommand) Execute(ctx context.Context, _ *flag.FlagSet, _ ...interface{}) subcommands.ExitStatus {
 	// read address from env or lock file
 	addr, err := beacon.Address(ctx, s.lockFile)
+	if errors.Is(err, beacon.ErrIntegrationDisabled) {
+		log.Println(err)
+		return subcommands.ExitFailure
+	}
 	if err != nil {
-		log.Printf("failed to read lock file %q", s.lockFile)
+		log.Printf("failed to read lock file %q\n", s.lockFile)
 		log.Println(err)
 		return subcommands.ExitFailure
 	}

--- a/internal/cmd/commands_test.go
+++ b/internal/cmd/commands_test.go
@@ -57,6 +57,23 @@ func TestNewCommands_Help(t *testing.T) {
 	}
 }
 
+func TestStopCommand_IntegrationDisabled(t *testing.T) {
+	ctx := context.Background()
+
+	f := flag.NewFlagSet("confort", flag.ContinueOnError)
+	cmd := NewCommands(f, NewOperation())
+	err := f.Parse([]string{"stop"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv(beacon.AddressEnv, "disabled")
+	code := cmd.Execute(ctx, nil)
+	if code != 1 {
+		t.Fatalf("unexpected exit code: %d", code)
+	}
+}
+
 func TestTestCommand_determineGoCommand(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
To disable it explicitly, set `CFT_BEACON_ADDR=disabled`. This allows to skip the waiting loop of `beacon.Address` in `confort.WithBeacon` and `unique.WithBeacon`.

Closes #36 