### PR TITLE
Add internal/logging: optional logging

### DIFF
--- a/confort_test.go
+++ b/confort_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httputil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -45,6 +46,9 @@ func TestMain(m *testing.M) {
 	ctx := context.Background()
 	c, cleanup := NewControl()
 	defer cleanup()
+
+	// enable debug log TODO: use testingc package
+	os.Setenv(beacon.LogLevelEnv, "0")
 
 	var term func()
 	cft := confort.New(c, ctx,

--- a/e2e/tenant/tests/main_test.go
+++ b/e2e/tenant/tests/main_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/daichitakahashi/confort/e2e/tenant/database"
+	"github.com/daichitakahashi/confort/internal/beacon"
 	"github.com/daichitakahashi/confort/unique"
 	"github.com/daichitakahashi/testingc"
 )
@@ -19,6 +20,8 @@ func TestMain(m *testing.M) { testingc.M(m, testMain) }
 
 func testMain(m *testingc.MC) int {
 	ctx := context.Background()
+	m.Setenv(beacon.LogLevelEnv, "0")
+
 	connect = database.InitDatabase(m, ctx)
 	uniqueTenantName = unique.String(10, unique.WithBeacon(m, ctx, "tenant_name"))
 	uniqueEmployeeUserName = unique.String(10, unique.WithBeacon(m, ctx, "employee_username"))

--- a/internal/beacon/addr.go
+++ b/internal/beacon/addr.go
@@ -3,7 +3,6 @@ package beacon
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io/fs"
 	"os"
 	"strings"
@@ -54,7 +53,7 @@ func Address(ctx context.Context, lockFile string) (string, error) {
 			return "", ctx.Err()
 		}
 	}
-	return "", fmt.Errorf("failed to read lock file: %s", lockFile)
+	return "", nil
 }
 
 func StoreAddressToLockFile(lockFile, addr string) error {

--- a/internal/beacon/env.go
+++ b/internal/beacon/env.go
@@ -6,4 +6,5 @@ const (
 	IdentifierEnv     = "CFT_IDENTIFIER"
 	NamespaceEnv      = "CFT_NAMESPACE"
 	ResourcePolicyEnv = "CFT_RESOURCE_POLICY"
+	LogLevelEnv       = "CFT_LOG_LEVEL"
 )

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,93 @@
+package logging
+
+import (
+	"fmt"
+	"path"
+	"runtime"
+	"testing"
+)
+
+type LogLevel int
+
+const (
+	LevelDebug LogLevel = iota
+	LevelInfo
+	LevelError
+)
+
+var level = LevelError
+
+func (l LogLevel) enabled(base LogLevel) bool {
+	return base <= l
+}
+
+// SetLogLevel sets log level.
+// This func is unsafe for concurrent use.
+func SetLogLevel(l LogLevel) {
+	level = l
+}
+
+var (
+	debugPrefix = "confort[DEBUG]:"
+	infoPrefix  = "confort[INFO]:"
+	errorPrefix = "confort[ERROR]:"
+	fatalPrefix = "confort[FATAL]:"
+)
+
+func file(depth int) string {
+	pc, filename, line, _ := runtime.Caller(depth)
+	funcName := path.Base(runtime.FuncForPC(pc).Name())
+	return fmt.Sprintf("\n\t%s:%d:%s", filename, line, funcName)
+}
+
+func Debug(tb testing.TB, args ...any) {
+	tb.Helper()
+	if LevelDebug.enabled(level) {
+		tb.Log(debugPrefix, fmt.Sprint(args...), file(2))
+	}
+}
+
+func Debugf(tb testing.TB, format string, args ...any) {
+	tb.Helper()
+	if LevelDebug.enabled(level) {
+		tb.Log(debugPrefix, fmt.Sprintf(format, args...), file(2))
+	}
+}
+
+func Info(tb testing.TB, args ...any) {
+	tb.Helper()
+	if LevelInfo.enabled(level) {
+		tb.Log(infoPrefix, fmt.Sprint(args...))
+	}
+}
+
+func Infof(tb testing.TB, format string, args ...any) {
+	tb.Helper()
+	if LevelInfo.enabled(level) {
+		tb.Log(infoPrefix, fmt.Sprintf(format, args...))
+	}
+}
+
+func Error(tb testing.TB, args ...any) {
+	tb.Helper()
+	if LevelError.enabled(level) {
+		tb.Log(errorPrefix, fmt.Sprint(args...), file(2))
+	}
+}
+
+// func Errorf(tb testing.TB, format string, args ...any) {
+// 	tb.Helper()
+// 	if LevelError.enabled(level) {
+// 		tb.Log(errorPrefix, fmt.Sprintf(format, args...), file(2))
+// 	}
+// }
+
+func Fatal(tb testing.TB, args ...any) {
+	tb.Helper()
+	tb.Fatal(fatalPrefix, fmt.Sprint(args...), file(2))
+}
+
+func Fatalf(tb testing.TB, format string, args ...any) {
+	tb.Helper()
+	tb.Fatalf(fatalPrefix, fmt.Sprintf(format, args...), file(2))
+}

--- a/unique/unique.go
+++ b/unique/unique.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/daichitakahashi/confort/internal/beacon"
 	"github.com/daichitakahashi/confort/internal/beacon/proto"
+	"github.com/daichitakahashi/confort/internal/logging"
 	"github.com/lestrrat-go/option"
 )
 
@@ -115,7 +116,7 @@ func (u *Unique[T]) Must(tb testing.TB) T {
 
 	v, err := u.g.generate(u.retry)
 	if err != nil {
-		tb.Fatal(err)
+		logging.Fatal(tb, err)
 	}
 	return v
 }


### PR DESCRIPTION
Log level can be set via an environment variable `CFT_LOG_LEVEL=<level>`(e.g. `CFT_LOG_LEVEL=0`)

* 0: show log about detailed behavior of `confort.Confort`
* 1: show log about settings actually took effect as a result of the combination of environment variables and options
  * `CFT_NAMESPACE` and `confort.WithNamecspace`
  * `CFT_RESOURCE_POLICY` and `confort.WithResourcePolicy`
  * `confort.WithBeacon`
  * `unique.WithBeacon`
* 2: show log about runtime error(default)

Closes #37 