### PR TITLE
Remove `testing.TB` from arguments and return error

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -442,7 +442,7 @@ func (d *dockerNamespace) StartContainer(ctx context.Context, name string) (Port
 	c, ok := d.containers[name]
 	d.m.RUnlock()
 	if !ok {
-		return nil, errors.New(containerNotFound(name))
+		return nil, fmt.Errorf("dockerNamespace: container %q not found", name)
 	} else if c.running {
 		return c.ports, nil
 	}
@@ -471,10 +471,6 @@ func (d *dockerNamespace) StartContainer(ctx context.Context, name string) (Port
 	c.running = true
 	c.ports = Ports(portMap)
 	return c.ports, nil
-}
-
-func containerNotFound(name string) string {
-	return fmt.Sprintf("dockerBackend: container %q not found", name)
 }
 
 func (d *dockerNamespace) Release(ctx context.Context) error {

--- a/confort.go
+++ b/confort.go
@@ -168,7 +168,7 @@ func New(ctx context.Context, opts ...NewOption) (cft *Confort, err error) {
 			o := opt.Value().(namespaceOption)
 			if namespace == "" || o.force {
 				if namespace != "" {
-					logging.Infof(nil, "namespace is overwritten by WithNamespace: %q -> %q", namespace, o.namespace)
+					logging.Infof("namespace is overwritten by WithNamespace: %q -> %q", namespace, o.namespace)
 				}
 				namespace = o.namespace
 			}
@@ -177,7 +177,7 @@ func New(ctx context.Context, opts ...NewOption) (cft *Confort, err error) {
 		case identOptionResourcePolicy{}:
 			newPolicy := opt.Value().(ResourcePolicy)
 			if policy != "" && policy != newPolicy {
-				logging.Infof(nil, "resource policy is overwritten by WithResourcePolicy: %q -> %q", policy, newPolicy)
+				logging.Infof("resource policy is overwritten by WithResourcePolicy: %q -> %q", policy, newPolicy)
 			}
 			policy = newPolicy
 		case identOptionBeacon{}:
@@ -205,7 +205,7 @@ func New(ctx context.Context, opts ...NewOption) (cft *Confort, err error) {
 	if namespace == "" {
 		return nil, errors.New("confort: empty namespace")
 	}
-	logging.Debugf(nil, "namespace: %s", namespace)
+	logging.Debugf("namespace: %s", namespace)
 
 	if policy == "" {
 		policy = ResourcePolicyReuse // default
@@ -213,7 +213,7 @@ func New(ctx context.Context, opts ...NewOption) (cft *Confort, err error) {
 	if !beacon.ValidResourcePolicy(string(policy)) {
 		return nil, fmt.Errorf("confort: invalid resource policy: %s", policy)
 	}
-	logging.Debugf(nil, "resource policy: %s", policy)
+	logging.Debugf("resource policy: %s", policy)
 
 	ctx, cancel := applyTimeout(ctx, timeout)
 	defer cancel()
@@ -235,17 +235,17 @@ func New(ctx context.Context, opts ...NewOption) (cft *Confort, err error) {
 		},
 	}
 
-	logging.Debug(nil, "acquire LockForNamespace")
+	logging.Debug("acquire LockForNamespace")
 	unlock, err := ex.LockForNamespace(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("confort: %w", err)
 	}
 	defer func() {
-		logging.Debug(nil, "release LockForNamespace")
+		logging.Debug("release LockForNamespace")
 		unlock()
 	}()
 
-	logging.Debugf(nil, "create namespace %q", namespace)
+	logging.Debugf("create namespace %q", namespace)
 	ns, err := backend.Namespace(ctx, namespace)
 	if err != nil {
 		return nil, fmt.Errorf("confort: %w", err)
@@ -261,7 +261,7 @@ func New(ctx context.Context, opts ...NewOption) (cft *Confort, err error) {
 			return err
 		}
 		// release all resources
-		logging.Debugf(nil, "release all resources bound with namespace %q", namespace)
+		logging.Debugf("release all resources bound with namespace %q", namespace)
 		return multierr.Append(err, ns.Release(context.Background()))
 	}
 
@@ -390,17 +390,17 @@ func (cft *Confort) Build(ctx context.Context, b *BuildParams, opts ...BuildOpti
 	if len(buildOption.Tags) == 0 {
 		return errors.New("confort: image tag not specified")
 	}
-	logging.Debugf(nil, "LockForBuild: %s", buildOption.Tags[0])
+	logging.Debugf("LockForBuild: %s", buildOption.Tags[0])
 	unlock, err := cft.ex.LockForBuild(ctx, buildOption.Tags[0])
 	if err != nil {
 		return fmt.Errorf("confort: %w", err)
 	}
 	defer func() {
-		logging.Debugf(nil, "release LockForBuild: %s", buildOption.Tags[0])
+		logging.Debugf("release LockForBuild: %s", buildOption.Tags[0])
 		unlock()
 	}()
 
-	logging.Debugf(nil, "build image %q", buildOption.Tags[0])
+	logging.Debugf("build image %q", buildOption.Tags[0])
 	err = cft.backend.BuildImage(ctx, tarball, buildOption, force, buildOut)
 	if err != nil {
 		return fmt.Errorf("confort: %w", err)
@@ -587,17 +587,17 @@ func (cft *Confort) LazyRun(ctx context.Context, c *ContainerParams, opts ...Run
 	ctx, cancel := applyTimeout(ctx, cft.defaultTimeout)
 	defer cancel()
 
-	logging.Debugf(nil, "acquire LockForContainerSetup: %s", name)
+	logging.Debugf("acquire LockForContainerSetup: %s", name)
 	unlock, err := cft.ex.LockForContainerSetup(ctx, name)
 	if err != nil {
 		return nil, fmt.Errorf("confort: %w", err)
 	}
 	defer func() {
-		logging.Debugf(nil, "release LockForContainerSetup: %s", name)
+		logging.Debugf("release LockForContainerSetup: %s", name)
 		unlock()
 	}()
 
-	logging.Debugf(nil, "create container if not exists: %s", name)
+	logging.Debugf("create container if not exists: %s", name)
 	containerID, err := cft.createContainer(ctx, name, alias, c, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("confort: %w", err)
@@ -626,23 +626,23 @@ func (cft *Confort) Run(ctx context.Context, c *ContainerParams, opts ...RunOpti
 	ctx, cancel := applyTimeout(ctx, cft.defaultTimeout)
 	defer cancel()
 
-	logging.Debugf(nil, "acquire LockForContainerSetup: %s", name)
+	logging.Debugf("acquire LockForContainerSetup: %s", name)
 	unlock, err := cft.ex.LockForContainerSetup(ctx, name)
 	if err != nil {
 		return nil, fmt.Errorf("confort: %w", err)
 	}
 	defer func() {
-		logging.Debugf(nil, "release LockForContainerSetup: %s", name)
+		logging.Debugf("release LockForContainerSetup: %s", name)
 		unlock()
 	}()
 
-	logging.Debugf(nil, "create container if not exists: %s", name)
+	logging.Debugf("create container if not exists: %s", name)
 	containerID, err := cft.createContainer(ctx, name, alias, c, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("confort: %w", err)
 	}
 
-	logging.Debugf(nil, "start container if not started: %s", name)
+	logging.Debugf("start container if not started: %s", name)
 	_, err = cft.namespace.StartContainer(ctx, name)
 	if err != nil {
 		return nil, fmt.Errorf("confort: %w", err)
@@ -698,17 +698,17 @@ func (c *Container) Use(ctx context.Context, exclusive bool, opts ...UseOption) 
 		}
 	}
 
-	logging.Debugf(nil, "acquire LockForContainerSetup: %s", c.name)
+	logging.Debugf("acquire LockForContainerSetup: %s", c.name)
 	unlock, err := c.cft.ex.LockForContainerSetup(ctx, c.name)
 	if err != nil {
 		return nil, nil, fmt.Errorf("confort: %w", err)
 	}
 	defer func() {
-		logging.Debugf(nil, "release LockForContainerSetup: %s", c.name)
+		logging.Debugf("release LockForContainerSetup: %s", c.name)
 		unlock()
 	}()
 
-	logging.Debugf(nil, "start container if not started: %s", c.name)
+	logging.Debugf("start container if not started: %s", c.name)
 	ports, err := c.cft.namespace.StartContainer(ctx, c.name)
 	if err != nil {
 		return nil, nil, fmt.Errorf("confort: %w", err)
@@ -717,20 +717,20 @@ func (c *Container) Use(ctx context.Context, exclusive bool, opts ...UseOption) 
 	var init func() error
 	if initFunc != nil {
 		init = func() error {
-			logging.Debugf(nil, "call InitFunc: %s", c.name)
+			logging.Debugf("call InitFunc: %s", c.name)
 			return initFunc(ctx, ports)
 		}
 	}
 	// If initFunc is not nil, it will be called after acquisition of exclusive lock.
 	// After that, the lock is downgraded to shared lock when exclusive is false.
 	// When initFunc returns error, the acquisition of lock fails.
-	logging.Debugf(nil, "acquire LockForContainerUse: %s(exclusive=%t)", c.name, exclusive)
+	logging.Debugf("acquire LockForContainerUse: %s(exclusive=%t)", c.name, exclusive)
 	unlockContainer, err := c.cft.ex.LockForContainerUse(ctx, c.name, exclusive, init)
 	if err != nil {
 		return nil, nil, fmt.Errorf("confort: %w", err)
 	}
 	release := func() {
-		logging.Debugf(nil, "release LockForContainerUse: %s(exclusive=%t)", c.name, exclusive)
+		logging.Debugf("release LockForContainerUse: %s(exclusive=%t)", c.name, exclusive)
 		unlockContainer()
 	}
 

--- a/confort_test.go
+++ b/confort_test.go
@@ -139,7 +139,11 @@ func TestConfort_Run_Communication(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	portsOne := comOne.UseExclusive(t, ctx)
+	portsOne, releaseOne, err := comOne.UseExclusive(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(releaseOne)
 	hostOne := portsOne.HostPort("80/tcp")
 	if hostOne == "" {
 		t.Logf("%#v", portsOne)
@@ -158,7 +162,11 @@ func TestConfort_Run_Communication(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	portsTwo := comTwo.UseExclusive(t, ctx)
+	portsTwo, releaseTwo, err := comTwo.UseExclusive(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(releaseTwo)
 	hostTwo := portsTwo.HostPort("80/tcp")
 	if hostTwo == "" {
 		t.Fatal("two: bound port not found")
@@ -212,7 +220,11 @@ func TestConfort_Run_ContainerIdentification(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		ports := echo.UseShared(t, ctx)
+		ports, release, err := echo.UseShared(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(release)
 		endpoint := ports.HostPort(nat.Port(port))
 		if endpoint == "" {
 			t.Fatalf("cannot get endpoint of %q: %v", port, ports)
@@ -332,8 +344,16 @@ func TestConfort_LazyRun(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		e1 := echo.UseShared(t, ctx)
-		e2 := echo.UseShared(t, ctx)
+		e1, release1, err := echo.UseShared(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(release1)
+		e2, release2, err := echo.UseShared(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(release2)
 		if diff := cmp.Diff(e1, e2); diff != "" {
 			t.Fatal(diff)
 		}
@@ -360,7 +380,11 @@ func TestConfort_LazyRun(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		e1 := echo1.UseShared(t, ctx)
+		e1, release1, err := echo1.UseShared(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(release1)
 
 		cft2, err := confort.New(ctx,
 			confort.WithNamespace(namespace, true),
@@ -376,7 +400,12 @@ func TestConfort_LazyRun(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		e2 := echo2.UseShared(t, ctx)
+		e2, release2, err := echo2.UseShared(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(release2)
+
 		if diff := cmp.Diff(e1, e2); diff != "" {
 			t.Fatal(diff)
 		}
@@ -425,7 +454,11 @@ func TestConfort_Run_AttachAliasToAnotherNetwork(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	e := com1.UseShared(t, ctx)
+	e, release1, err := com1.UseShared(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(release1)
 	hostA := e.HostPort("80/tcp")
 	if hostA == "" {
 		t.Fatal("failed to get host/port")
@@ -445,7 +478,11 @@ func TestConfort_Run_AttachAliasToAnotherNetwork(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	e = com2.UseShared(t, ctx)
+	e, release2, err := com2.UseShared(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(release2)
 	hostB := e.HostPort("80/tcp")
 	if hostB == "" {
 		t.Fatal("failed to get host/port")
@@ -473,7 +510,11 @@ func TestConfort_Run_AttachAliasToAnotherNetwork(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	e = com3.UseShared(t, ctx)
+	e, release3, err := com3.UseShared(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(release3)
 	hostB2 := e.HostPort("80/tcp")
 	if hostB2 == "" {
 		t.Fatal("failed to get host/port")
@@ -494,7 +535,11 @@ func TestConfort_Run_AttachAliasToAnotherNetwork(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	e = com4.UseShared(t, ctx)
+	e, release4, err := com4.UseShared(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(release4)
 	hostC := e.HostPort("80/tcp")
 	if hostC == "" {
 		t.Fatal("failed to get host/port")
@@ -1460,7 +1505,11 @@ func TestWithHostConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ports := communicator.UseExclusive(t, ctx)
+	ports, release, err := communicator.UseExclusive(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(release)
 	host := ports.HostPort("80/tcp")
 	if host == "" {
 		t.Fatal("two: bound port not found")
@@ -1512,7 +1561,12 @@ func TestWithNetworkingConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	host := communicator.UseExclusive(t, ctx).HostPort("80/tcp")
+	ports, release, err := communicator.UseExclusive(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(release)
+	host := ports.HostPort("80/tcp")
 	if host == "" {
 		t.Fatalf("%s: bound port not found", name)
 	}
@@ -1667,7 +1721,12 @@ func TestWithPullOptions(t *testing.T) {
 	}
 
 	// check if container works
-	ports := c.UseShared(t, ctx)
+	ports, release, err := c.UseShared(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(release)
+
 	endpoint := ports.HostPort("80/tcp")
 	if endpoint == "" {
 		t.Fatal("endpoint not found")
@@ -1682,53 +1741,6 @@ func TestWithPullOptions(t *testing.T) {
 	removed := removeImageIfExists(t, cli, pullImage)
 	if !removed {
 		t.Fatalf("cannot remove pulled image %q", pullImage)
-	}
-}
-
-func TestWithReleaseFunc(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
-
-	cft, err := confort.New(ctx, confort.WithNamespace(t.Name(), true))
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() {
-		_ = cft.Close()
-	})
-
-	echo, err := cft.Run(ctx, &confort.ContainerParams{
-		Name:         "echo",
-		Image:        imageEcho,
-		ExposedPorts: []string{"80/tcp"},
-		Waiter:       wait.Healthy(),
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// test that the container is not released until the release is called.
-	var release func()
-	result := testingc.Test(func(t *testingc.T) {
-		echo.UseExclusive(t, ctx, confort.WithReleaseFunc(&release))
-	})
-	if result.Failed() {
-		t.Fatal(string(result.Logs()))
-	}
-
-	use := func(t *testingc.T) {
-		ctx, cancel := context.WithTimeout(ctx, time.Second)
-		defer cancel()
-		echo.UseExclusive(t, ctx)
-	}
-	if !testingc.Test(use).Failed() {
-		release()
-		t.Fatal("timeout expected")
-	}
-
-	release()
-	if result := testingc.Test(use); result.Failed() {
-		t.Fatalf("unexpected failure: %s", result.Logs())
 	}
 }
 
@@ -1755,8 +1767,8 @@ func TestWithInitFunc(t *testing.T) {
 	}
 
 	var try, done int
-	use := func(t *testingc.T) {
-		echo.UseShared(t, ctx, confort.WithInitFunc(func(ctx context.Context, ports confort.Ports) error {
+	use := func() error {
+		_, release, err := echo.UseShared(ctx, confort.WithInitFunc(func(ctx context.Context, ports confort.Ports) error {
 			if try++; try < 3 {
 				return errors.New("dummy error")
 			}
@@ -1766,18 +1778,22 @@ func TestWithInitFunc(t *testing.T) {
 			done++
 			return nil
 		}))
+		if err == nil {
+			t.Cleanup(release)
+		}
+		return err
 	}
 
 	for i := 0; i < 5; i++ {
-		result := testingc.Test(use)
+		err := use()
 		if i < 2 {
-			if !result.Failed() {
+			if err == nil {
 				t.Fatal("expected error on init")
 			}
 			continue
 		}
-		if result.Failed() {
-			t.Fatalf("unexpected failure: %s", result.Logs())
+		if err != nil {
+			t.Fatalf("unexpected failure: %s", err)
 		}
 	}
 	if done != 1 {

--- a/confort_test.go
+++ b/confort_test.go
@@ -1252,42 +1252,6 @@ func TestWithBeacon(t *testing.T) {
 	})
 }
 
-//
-// func TestWithTerminateFunc(t *testing.T) {
-// 	t.Parallel()
-// 	ctx := context.Background()
-//
-// 	cli, err := client.NewClientWithOpts(client.FromEnv)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-//
-// 	cft, err := confort.New(ctx,
-// 		confort.WithNamespace(t.Name(), true),
-// 	)
-// 	if err != nil {
-// 		t.Fatal(err)
-// 	}
-//
-// 	nw := cft.Network()
-//
-// 	// check network is alive
-// 	_, err = cli.NetworkInspect(ctx, nw.ID, types.NetworkInspectOptions{})
-// 	if err != nil {
-// 		_ = cft.Close()
-// 		t.Fatal(err)
-// 	}
-//
-// 	// terminate
-// 	_ = cft.Close()
-//
-// 	// check network is removed
-// 	actual, err := cli.NetworkInspect(ctx, nw.ID, types.NetworkInspectOptions{})
-// 	if err == nil {
-// 		t.Fatalf("network expected to be removed, but exists: name=%q", actual.Name)
-// 	}
-// }
-
 func TestWithImageBuildOptions(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/e2e/interrupt/tests/interrupt_test.go
+++ b/e2e/interrupt/tests/interrupt_test.go
@@ -19,10 +19,16 @@ func TestInterrupt(t *testing.T) {
 	t.Log("connecting beacon server")
 
 	// create container
-	cft := confort.New(t, ctx,
+	cft, err := confort.New(ctx,
 		confort.WithNamespace(uuid.NewString(), false),
 		confort.WithBeacon(),
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = cft.Close()
+	})
 	cft.Run(t, ctx, &confort.ContainerParams{
 		Name:  "container",
 		Image: "alpine:3.16.2",

--- a/e2e/interrupt/tests/interrupt_test.go
+++ b/e2e/interrupt/tests/interrupt_test.go
@@ -29,11 +29,14 @@ func TestInterrupt(t *testing.T) {
 	t.Cleanup(func() {
 		_ = cft.Close()
 	})
-	cft.Run(t, ctx, &confort.ContainerParams{
+	_, err = cft.Run(ctx, &confort.ContainerParams{
 		Name:  "container",
 		Image: "alpine:3.16.2",
 		Cmd:   []string{"sleep", "infinity"},
 	}, confort.WithPullOptions(&types.ImagePullOptions{}, io.Discard))
+	if err != nil {
+		t.Fatal(err)
+	}
 	t.Log("container is ready")
 
 	time.Sleep(time.Second * 20)

--- a/e2e/tenant/database/container.go
+++ b/e2e/tenant/database/container.go
@@ -38,7 +38,7 @@ func InitDatabase(tb testing.TB, ctx context.Context) ConnectFunc {
 		_ = cft.Close()
 	})
 
-	db := cft.Run(tb, ctx, &confort.ContainerParams{
+	db, err := cft.Run(ctx, &confort.ContainerParams{
 		Name:  "db",
 		Image: "postgres:14.4-alpine3.16",
 		Env: map[string]string{
@@ -57,6 +57,9 @@ func InitDatabase(tb testing.TB, ctx context.Context) ConnectFunc {
 			}
 		}),
 	)
+	if err != nil {
+		tb.Fatal(err)
+	}
 
 	return func(tb testing.TB, ctx context.Context, exclusive bool) *pgxpool.Pool {
 		tb.Helper()

--- a/e2e/tenant/database/container.go
+++ b/e2e/tenant/database/container.go
@@ -27,10 +27,16 @@ const (
 func InitDatabase(tb testing.TB, ctx context.Context) ConnectFunc {
 	tb.Helper()
 
-	cft := confort.New(tb, ctx,
+	cft, err := confort.New(ctx,
 		confort.WithBeacon(),
 		confort.WithNamespace("integrationtest", false),
 	)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	tb.Cleanup(func() {
+		_ = cft.Close()
+	})
 
 	db := cft.Run(tb, ctx, &confort.ContainerParams{
 		Name:  "db",

--- a/e2e/tenant/tests/main_test.go
+++ b/e2e/tenant/tests/main_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/daichitakahashi/confort/e2e/tenant/database"
@@ -20,10 +21,24 @@ func TestMain(m *testing.M) { testingc.M(m, testMain) }
 
 func testMain(m *testingc.MC) int {
 	ctx := context.Background()
-	m.Setenv(beacon.LogLevelEnv, "0")
+	err := os.Setenv(beacon.LogLevelEnv, "0")
+	if err != nil {
+		m.Fatal(err)
+	}
 
 	connect = database.InitDatabase(m, ctx)
-	uniqueTenantName = unique.String(10, unique.WithBeacon(m, ctx, "tenant_name"))
-	uniqueEmployeeUserName = unique.String(10, unique.WithBeacon(m, ctx, "employee_username"))
+	uniqueTenantName, err = unique.String(ctx, 10,
+		unique.WithBeacon("tenant_name"),
+	)
+	if err != nil {
+		m.Fatal(err)
+	}
+	uniqueEmployeeUserName, err = unique.String(ctx, 10,
+		unique.WithBeacon("employee_username"),
+	)
+	if err != nil {
+		m.Fatal(err)
+	}
+
 	return m.Run()
 }

--- a/internal/beacon/beacon.go
+++ b/internal/beacon/beacon.go
@@ -48,16 +48,16 @@ func connect(ctx context.Context) (*Connection, error) {
 	addr, err := Address(ctx, LockFilePath())
 	if err != nil {
 		if errors.Is(err, ErrIntegrationDisabled) {
-			logging.Info(nil, err)
+			logging.Info(err)
 			return &Connection{}, nil
 		}
 		return nil, err
 	}
 	if addr == "" {
-		logging.Info(nil, "cannot get the address of beacon server")
+		logging.Info("cannot get the address of beacon server")
 		return &Connection{}, nil
 	}
-	logging.Debugf(nil, "the address of beacon server: %s", addr)
+	logging.Debugf("the address of beacon server: %s", addr)
 
 	conn, err := grpc.DialContext(ctx, addr, grpc.WithTransportCredentials(
 		insecure.NewCredentials(),
@@ -79,7 +79,7 @@ func connect(ctx context.Context) (*Connection, error) {
 			Service: "beacon",
 		})
 		status = resp.GetStatus()
-		logging.Debugf(nil, "got health check status of beacon server: %s", status)
+		logging.Debugf("got health check status of beacon server: %s", status)
 		if status == health.HealthCheckResponse_SERVING {
 			break
 		}

--- a/internal/beacon/server/beacon_test.go
+++ b/internal/beacon/server/beacon_test.go
@@ -10,7 +10,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-var uniq = unique.New(func() (string, error) {
+var uniq, _ = unique.New(context.Background(), func() (string, error) {
 	return uuid.New().String(), nil
 })
 

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -41,6 +41,9 @@ func file(depth int) string {
 }
 
 func Debug(tb testing.TB, args ...any) {
+	if tb == nil {
+		return
+	}
 	tb.Helper()
 	if LevelDebug.enabled(level) {
 		tb.Log(debugPrefix, fmt.Sprint(args...), file(2))
@@ -48,6 +51,9 @@ func Debug(tb testing.TB, args ...any) {
 }
 
 func Debugf(tb testing.TB, format string, args ...any) {
+	if tb == nil {
+		return
+	}
 	tb.Helper()
 	if LevelDebug.enabled(level) {
 		tb.Log(debugPrefix, fmt.Sprintf(format, args...), file(2))
@@ -55,6 +61,9 @@ func Debugf(tb testing.TB, format string, args ...any) {
 }
 
 func Info(tb testing.TB, args ...any) {
+	if tb == nil {
+		return
+	}
 	tb.Helper()
 	if LevelInfo.enabled(level) {
 		tb.Log(infoPrefix, fmt.Sprint(args...))
@@ -62,6 +71,9 @@ func Info(tb testing.TB, args ...any) {
 }
 
 func Infof(tb testing.TB, format string, args ...any) {
+	if tb == nil {
+		return
+	}
 	tb.Helper()
 	if LevelInfo.enabled(level) {
 		tb.Log(infoPrefix, fmt.Sprintf(format, args...))
@@ -69,6 +81,9 @@ func Infof(tb testing.TB, format string, args ...any) {
 }
 
 func Error(tb testing.TB, args ...any) {
+	if tb == nil {
+		return
+	}
 	tb.Helper()
 	if LevelError.enabled(level) {
 		tb.Log(errorPrefix, fmt.Sprint(args...), file(2))

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -2,9 +2,9 @@ package logging
 
 import (
 	"fmt"
+	"log"
 	"path"
 	"runtime"
-	"testing"
 )
 
 type LogLevel int
@@ -30,8 +30,6 @@ func SetLogLevel(l LogLevel) {
 var (
 	debugPrefix = "confort[DEBUG]:"
 	infoPrefix  = "confort[INFO]:"
-	errorPrefix = "confort[ERROR]:"
-	fatalPrefix = "confort[FATAL]:"
 )
 
 func file(depth int) string {
@@ -40,69 +38,26 @@ func file(depth int) string {
 	return fmt.Sprintf("\n\t%s:%d:%s", filename, line, funcName)
 }
 
-func Debug(tb testing.TB, args ...any) {
-	if tb == nil {
-		return
-	}
-	tb.Helper()
+func Debug(args ...any) {
 	if LevelDebug.enabled(level) {
-		tb.Log(debugPrefix, fmt.Sprint(args...), file(2))
+		log.Println(debugPrefix, fmt.Sprint(args...), file(2))
 	}
 }
 
-func Debugf(tb testing.TB, format string, args ...any) {
-	if tb == nil {
-		return
-	}
-	tb.Helper()
+func Debugf(format string, args ...any) {
 	if LevelDebug.enabled(level) {
-		tb.Log(debugPrefix, fmt.Sprintf(format, args...), file(2))
+		log.Println(debugPrefix, fmt.Sprintf(format, args...), file(2))
 	}
 }
 
-func Info(tb testing.TB, args ...any) {
-	if tb == nil {
-		return
-	}
-	tb.Helper()
+func Info(args ...any) {
 	if LevelInfo.enabled(level) {
-		tb.Log(infoPrefix, fmt.Sprint(args...))
+		log.Println(infoPrefix, fmt.Sprint(args...))
 	}
 }
 
-func Infof(tb testing.TB, format string, args ...any) {
-	if tb == nil {
-		return
-	}
-	tb.Helper()
+func Infof(format string, args ...any) {
 	if LevelInfo.enabled(level) {
-		tb.Log(infoPrefix, fmt.Sprintf(format, args...))
+		log.Println(infoPrefix, fmt.Sprintf(format, args...))
 	}
-}
-
-func Error(tb testing.TB, args ...any) {
-	if tb == nil {
-		return
-	}
-	tb.Helper()
-	if LevelError.enabled(level) {
-		tb.Log(errorPrefix, fmt.Sprint(args...), file(2))
-	}
-}
-
-// func Errorf(tb testing.TB, format string, args ...any) {
-// 	tb.Helper()
-// 	if LevelError.enabled(level) {
-// 		tb.Log(errorPrefix, fmt.Sprintf(format, args...), file(2))
-// 	}
-// }
-
-func Fatal(tb testing.TB, args ...any) {
-	tb.Helper()
-	tb.Fatal(fatalPrefix, fmt.Sprint(args...), file(2))
-}
-
-func Fatalf(tb testing.TB, format string, args ...any) {
-	tb.Helper()
-	tb.Fatalf(fatalPrefix, fmt.Sprintf(format, args...), file(2))
 }

--- a/unique/unique.go
+++ b/unique/unique.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/daichitakahashi/confort/internal/beacon"
 	"github.com/daichitakahashi/confort/internal/beacon/proto"
-	"github.com/daichitakahashi/confort/internal/logging"
 	"github.com/lestrrat-go/option"
 )
 
@@ -114,7 +113,7 @@ func (u *Unique[T]) Must(tb testing.TB) T {
 
 	v, err := u.g.generate(u.retry)
 	if err != nil {
-		logging.Fatal(tb, err)
+		tb.Fatal(err)
 	}
 	return v
 }


### PR DESCRIPTION
 ```go
// TB is the interface common to T, B, and F.
type TB interface {
	// ...

	// A private method to prevent users implementing the
	// interface and so future additions to it will not
	// violate Go 1 compatibility.
	private()
}
```

Using `testing.TB` implementation is not recommended.

In `TestMain`, use `log.Panic` when error was occurred.