### PR TITLE
Update wait: add `Fetcher.Exec` and `CommandSucceeds`

### DIFF
--- a/confort_test.go
+++ b/confort_test.go
@@ -212,7 +212,7 @@ func TestConfort_Run_ContainerIdentification(t *testing.T) {
 			Name:         containerName,
 			Image:        imageEcho,
 			ExposedPorts: []string{port},
-			Waiter:       wait.Healthy(),
+			Waiter:       wait.CommandSucceeds([]string{"wget", "-q", "--spider", "http://localhost"}),
 		})
 		if err != nil {
 			t.Fatal(err)

--- a/internal/mock/moq.go
+++ b/internal/mock/moq.go
@@ -1,3 +1,3 @@
-//go:generate go run github.com/matryer/moq@v0.2.7 -pkg mock -out fetcher_moq.gen.go ../../wait Fetcher:Fetcher
+//go:generate go run github.com/matryer/moq@v0.3.0 -pkg mock -out fetcher_moq.gen.go ../../wait Fetcher:Fetcher
 
 package mock


### PR DESCRIPTION
* Now, you can exec commands inside the container to check readiness